### PR TITLE
Adding a space, so that I can double click the path and select it without the dashes

### DIFF
--- a/show_status
+++ b/show_status
@@ -149,7 +149,7 @@ if __name__ == "__main__":
 		    result = bcolors.FAIL + "Changes" + bcolors.ENDC
 
                 # Write to screen
-                sys.stdout.write("--" + bcolors.OKBLUE + infile.ljust(55) + bcolors.ENDC + branch + " : " + result +"\n")
+                sys.stdout.write("-- " + bcolors.OKBLUE + infile.ljust(55) + bcolors.ENDC + branch + " : " + result +"\n")
 
             else:
                 #Print some repo details


### PR DESCRIPTION
Hi @MikePearce ,

As the titles says, I find it a bit annoying, when double clicking a line in the report, to select the dashes as well(whereas I only want the path). So I have just added a small space between the paths and the "--" line prefixes.

Thanks,
P.